### PR TITLE
Ignore Ruby Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle
 .env
+.ruby-version


### PR DESCRIPTION
Seens there's no required ruby version, so lets just ignore rbenv/rvm `.ruby-version`