### PR TITLE
Fix capybara dsl loading problem

### DIFF
--- a/balboa.rb
+++ b/balboa.rb
@@ -1,5 +1,6 @@
 require 'active_support/all'
 require 'capybara'
+require 'capybara/dsl'
 require 'capybara/poltergeist'
 require 'highline/import'
 require 'holidays'


### PR DESCRIPTION
I tried to run the punch script from the command line, and got this error message:

```console
`<class:Puncher>': uninitialized constant Capybara::DSL (NameError)
```

Requiring `capybara/dsl` on the beginning of the file solved the problem